### PR TITLE
Forces jira user to be local

### DIFF
--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -29,7 +29,7 @@ class jira::install {
     managehome       => true,
     uid              => $jira::uid,
     gid              => $jira::gid,
-
+    forcelocal       => true,
   }
 
   if ! defined(File[$jira::installdir]) {


### PR DESCRIPTION
Because the module tries to modify the user, the module will fail if the user is not local. This will force the user be local. I can't imagine a use case where you would want the user to not be local and have this module modify the jira user. It's pretty much this or take out jira user management.