### PR TITLE
No case for Amazon AMI

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -13,11 +13,14 @@ class jira::params {
         $service_file_location   = '/usr/lib/systemd/system/jira.service'
         $service_file_template   = 'jira/jira.service.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
-      } elsif $::operatingsystemmajrelease == '6' {
+      } elsif $::operatingsystemmajrelease == '6' or $::operatingsystem == 'Amazon'{
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]
         $service_file_location   = '/etc/init.d/jira'
         $service_file_template   = 'jira/jira.initscript.erb'
         $service_lockfile        = '/var/lock/subsys/jira'
+      } else {
+        fail("\"${module_name}\" provides no service parameters
+            for \"${::osfamily}\" - \"${::operatingsystemmajrelease}\"")
       }
     } /Debian/: {
         $json_packages           = [ 'rubygem-json', 'ruby-json' ]


### PR DESCRIPTION
The Amazon AMI $::osfamily is /RedHat/, but the $::operatingsystem is /Amazon/ and the $::operatingsystemmajrelease is /2015/.  This causes it to enter the conditional logic, and pass though without any value for $json_packages, $service_file_location, $service_file_template, and $service_lockfile.
    
This initial commit is the smallest possible change to fix the error I noticed.  I simply added a conditional to look for the Amazon $::operatingsystem value where we are using the init provider under the RedHat $::osfamily
    
I added a basic failure message as the default value if no conditions are met under the RedHat $::osfamily case.
    
A more complete solution could be made similar to the params.pp in https://github.com/elastic/puppet-elasticsearch/blob/master/manifests/params.pp.
    
I haven't written any rspec-puppet tests before, and I wouldn't mind writing some for this use case with a little guidance.