### PR TITLE
Fix mysql connector containment

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,17 +5,17 @@ sudo: false
 matrix:
   include:
   - rvm: 1.9.3
-    env: PUPPET_GEM_VERSION="~> 3.3.0"
+    env: PUPPET_GEM_VERSION="~> 3.4.0"
   - rvm: 1.9.3
     env: PUPPET_GEM_VERSION="~> 3.7.0"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0"
+    env: PUPPET_GEM_VERSION="~> 3.4.0"
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.3.0" STRICT_VARIABLES=yes
+    env: PUPPET_GEM_VERSION="~> 3.4.0" STRICT_VARIABLES=yes
   - rvm: 2.0.0
-    env: PUPPET_GEM_VERSION="~> 3.0" FUTURE_PARSER="yes"
+    env: PUPPET_GEM_VERSION="~> 3.4.0" FUTURE_PARSER="yes"
   - rvm: 2.1.0
-    env: PUPPET_GEM_VERSION="~> 3.0" STRICT_VARIABLES=yes FUTURE_PARSER="yes"
+    env: PUPPET_GEM_VERSION="~> 3.4.0" STRICT_VARIABLES=yes FUTURE_PARSER="yes"
 notifications:
   email:
     - merritt@krakowitzer.com

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -103,13 +103,14 @@ class jira::install {
 
   if $jira::db == 'mysql' and $jira::mysql_connector_manage {
     if $jira::staging_or_deploy == 'staging' {
-      class { 'jira::mysql_connector':
+      class { '::jira::mysql_connector':
         require => Staging::Extract[$file],
       }
     } elsif $jira::staging_or_deploy == 'deploy' {
-      class { 'jira::mysql_connector':
+      class { '::jira::mysql_connector':
         require => Deploy::File[$file],
       }
     }
+    contain ::jira::mysql_connector
   }
 }

--- a/metadata.json
+++ b/metadata.json
@@ -26,7 +26,7 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">=3.0.0 <4.0.0"
+      "version_requirement": ">=3.2.0 <4.0.0"
     },
     {
       "name": "puppet",


### PR DESCRIPTION
When using the mysql_connector download, the file is often times downloaded after the service is started.  This fix uses the contain function to make sure the mysql_connector class is contained in the install class, thus fixing dependancies.

It also updates the travis tests and the metadata.json to use the minimum versions of puppet that have the contain class.  This means that anyone still using Puppet Enterprise < 3.2 will not be able to use this module anymore, but that version has been long unsupported by Puppet Labs so this should not be an issue.