### PR TITLE
Update required Puppet version to 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -456,7 +456,7 @@ Enable external facts for puppet version. These facts are required to be enabled
 
 ##Limitations
 
-* Puppet 3.4+
+* Puppet 3.7+
 * Puppet Enterprise
 
 The puppetlabs repositories can be found at:

--- a/metadata.json
+++ b/metadata.json
@@ -26,11 +26,11 @@
   "requirements": [
     {
       "name": "pe",
-      "version_requirement": ">=3.2.0 <4.0.0"
+      "version_requirement": ">=3.7.0 <4.0.0"
     },
     {
       "name": "puppet",
-      "version_requirement": ">=3.4.0 <4.0.0"
+      "version_requirement": ">=3.7.0 <4.0.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
Due to bug PUP-1597 (https://tickets.puppetlabs.com/browse/PUP-1597), this module will raise an
error during catalog compilation ("Error: undefined method `ref' for nil:NilClass") when run with a
version of Puppet prior to 3.7 if "mysql" is used as the database.

Here is the commit that triggers the bug:
https://github.com/puppet-community/puppet-jira/commit/412efe3e7accb892bceadcf59b2d32f063faeb06#diff-a276806bea2dfcf1f57c33aee19c7309R114