### PR TITLE
Fix jira::mysql_connector_url

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,7 @@ class jira (
   $mysql_connector_product = 'mysql-connector-java',
   $mysql_connector_format  = 'tar.gz',
   $mysql_connector_install = '/opt/MySQL-connector',
-  $mysql_connector_URL     = 'http://cdn.mysql.com/Downloads/Connector-J',
+  $mysql_connector_URL     = 'https://dev.mysql.com/get/Downloads/Connector-J',
 
   # Configure database settings if you are pooling connections
   $enable_connection_pooling = false,

--- a/spec/classes/jira_mysql_connector_spec.rb
+++ b/spec/classes/jira_mysql_connector_spec.rb
@@ -24,7 +24,7 @@ describe 'jira::mysql_connector' do
           }
           it 'should deploy mysql connector 5.1.34 from tar.gz' do
             should contain_staging__file("mysql-connector-java-5.1.34.tar.gz").with({
-              'source' => 'http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-5.1.34.tar.gz',
+              'source' => 'https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.34.tar.gz',
             })
             should contain_staging__extract("mysql-connector-java-5.1.34.tar.gz").with({
               'target' => '/opt/MySQL-connector',


### PR DESCRIPTION
It seems http://cdn.mysql.com only hosts the latest version of mysql-connector-java, which is
currently 5.1.38. However, jira::mysql_connector_versions specifies an old version (5.1.34), which
results in a 404:
http://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-5.1.34.tar.gz

Fortunately, it seems https://dev.mysql.com/ has all the old versions. Plus, it uses SSL.
https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-5.1.34.tar.gz