### PR TITLE
Jira 7 Support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -149,6 +149,13 @@ class jira (
   validate_absolute_path($tomcatKeystoreFile)
   validate_re($tomcatKeystoreType, '^(JKS|JCEKS|PKCS12)$')
 
+  # The default Jira product starting with version 7 is 'jira-software'
+  if ((versioncmp($version, '7.0.0') > 0) and ($product == 'jira')) {
+    $product_name = 'jira-software'
+  } else {
+    $product_name = $product
+  }
+
   if defined('$::jira_version') {
     # If the running version of JIRA is less than the expected version of JIRA
     # Shut it down in preparation for upgrade.
@@ -158,7 +165,7 @@ class jira (
     }
   }
 
-  $webappdir    = "${installdir}/atlassian-${product}-${version}-standalone"
+  $webappdir    = "${installdir}/atlassian-${product_name}-${version}-standalone"
   if $dburl {
     $dburl_real = $dburl
   }

--- a/manifests/install.pp
+++ b/manifests/install.pp
@@ -40,7 +40,17 @@ class jira::install {
     }
   }
 
-  $file = "atlassian-${jira::product}-${jira::version}.${jira::format}"
+  # Examples of product tarballs from Atlassian
+  # Core                - atlassian-jira-core-7.0.3.tar.gz
+  # Software (pre-7)    - atlassian-jira-6.4.12.tar.gz
+  # Software (7 and up) - atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz
+
+  if ((versioncmp($jira::version, '7.0.0') < 0) or ($jira::product_name == 'jira-core')) {
+    $file = "atlassian-${jira::product_name}-${jira::version}.${jira::format}"
+  } else {
+    $file = "atlassian-${jira::product_name}-${jira::version}-jira-${jira::version}.${jira::format}"
+  }
+
   if $jira::staging_or_deploy == 'staging' {
 
     require staging

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -70,6 +70,26 @@ describe 'jira::config' do
             .with_content(/<Connector port=\"9229\"\s+maxThreads=/m) }
         end
 
+        context 'server.xml listeners' do
+          context 'default version' do
+            let(:params) {{
+              :version  => '6.3.4a',
+              :javahome => '/opt/java',
+            }}
+            it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
+              .with_content(/<Listener className=\"org.apache.catalina.core.JasperListener\"/) }
+          end
+
+          context 'version greater than 7' do
+            let(:params) {{
+              :version  => '7.0.4',
+              :javahome => '/opt/java',
+            }}
+            it { should contain_file('/opt/jira/atlassian-jira-software-7.0.4-standalone/conf/server.xml')
+              .with_content(/<Listener className=\"org.apache.catalina.core.JreMemoryLeakPreventionListener\"/) }
+          end
+        end
+
         context 'customise tomcat connector with a binding address' do
           let(:params) {{
             :version  => '6.3.4a',

--- a/spec/classes/jira_install_deploy_spec.rb
+++ b/spec/classes/jira_install_deploy_spec.rb
@@ -78,6 +78,35 @@ describe 'jira::install' do
     
           it { should_not contain_class('jira::mysql_connector')}
         end
+
+        context 'jira 7' do
+          context 'default product' do
+            let(:params) {{
+              :javahome    => '/opt/java',
+              :product     => 'jira',
+              :version     => '7.0.4',
+              :format      => 'tar.gz',
+              :installdir  => '/opt/jira',
+              :staging_or_deploy => 'deploy',
+            }}
+            it 'should deploy jira-software 7.0.4 from tar.gz' do
+              should contain_deploy__file("atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz")
+            end
+          end
+          context 'core product' do
+            let(:params) {{
+              :javahome    => '/opt/java',
+              :product     => 'jira-core',
+              :version     => '7.0.4',
+              :format      => 'tar.gz',
+              :installdir  => '/opt/jira',
+              :staging_or_deploy => 'deploy',
+            }}
+            it 'should deploy jira-core 7.0.4 from tar.gz' do
+              should contain_deploy__file("atlassian-jira-core-7.0.4.tar.gz")
+            end
+          end
+        end
       end
     end
   end

--- a/spec/classes/jira_install_staging_spec.rb
+++ b/spec/classes/jira_install_staging_spec.rb
@@ -43,6 +43,45 @@ describe 'jira::install' do
             })
           end
         end
+
+        context 'jira 7' do
+          context 'default product' do
+            let(:params) {{
+              :javahome    => '/opt/java',
+              :installdir  => '/opt/jira',
+              :product     => 'jira',
+              :version     => '7.0.4',
+              :downloadURL => 'http://www.atlassian.com/software/jira/downloads/binary',
+            }}
+            it 'should deploy jira-software 7.0.4 from tar.gz' do
+              should contain_staging__file("atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz").with({
+                'source' => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz',
+                })
+              should contain_staging__extract("atlassian-jira-software-7.0.4-jira-7.0.4.tar.gz").with({
+                'target' => '/opt/jira/atlassian-jira-software-7.0.4-standalone',
+                'creates' => '/opt/jira/atlassian-jira-software-7.0.4-standalone/conf',
+                })
+            end
+          end
+          context 'core product' do
+            let(:params) {{
+              :javahome    => '/opt/java',
+              :installdir  => '/opt/jira',
+              :product     => 'jira-core',
+              :version     => '7.0.4',
+              :downloadURL => 'http://www.atlassian.com/software/jira/downloads/binary',
+            }}
+            it 'should deploy jira-core 7.0.4 from tar.gz' do
+              should contain_staging__file("atlassian-jira-core-7.0.4.tar.gz").with({
+                'source' => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-core-7.0.4.tar.gz',
+                })
+              should contain_staging__extract("atlassian-jira-core-7.0.4.tar.gz").with({
+                'target' => '/opt/jira/atlassian-jira-core-7.0.4-standalone',
+                'creates' => '/opt/jira/atlassian-jira-core-7.0.4-standalone/conf',
+                })
+            end
+          end
+        end
     
         context 'overwriting params' do
           let(:params) {{

--- a/templates/server.xml.erb
+++ b/templates/server.xml.erb
@@ -30,10 +30,20 @@
 <Server port="8005" shutdown="SHUTDOWN">
 
     <!--APR library loader. Documentation at /docs/apr.html -->
-    <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on"/>
+    <Listener className="org.apache.catalina.core.AprLifecycleListener" SSLEngine="on" />
+    <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
+  <%- if (scope.function_versioncmp([@version, '7.0.0']) < 0) -%>
     <!--Initialize Jasper prior to webapps are loaded. Documentation at /docs/jasper-howto.html -->
     <Listener className="org.apache.catalina.core.JasperListener"/>
-    <Listener className="org.apache.catalina.mbeans.GlobalResourcesLifecycleListener"/>
+  <%- else -%>
+    <Listener className="org.apache.catalina.startup.VersionLoggerListener" />
+    <!-- Security listener. Documentation at /docs/config/listeners.html
+    <Listener className="org.apache.catalina.security.SecurityListener" />
+    -->
+    <!-- Prevent memory leaks due to use of particular java/javax APIs-->
+    <Listener className="org.apache.catalina.core.JreMemoryLeakPreventionListener" />
+    <Listener className="org.apache.catalina.core.ThreadLocalLeakPreventionListener" />
+  <%- end -%>
     <Service name="Catalina">
         <Connector port="<%= @tomcatPort %>"
                    <%- if @tomcatAddress -%>


### PR DESCRIPTION
Updates `server.xml` with JIRA 7's default settings and continues to support the installation and management of JIRA pre-7.