### PR TITLE
Adding template and configuration item for JIRA Datacenter

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,6 +153,14 @@ The shell of the JIRA user, defaults to '/bin/true'
 
 Enables or disables JIRA Secure Administrator Sessions, defaults to true
 
+#####`$datacenter`
+
+Enables or disables clustering, defaults to false
+
+#####`$shared_homedir`
+
+The directory of the shared home directory, defaults to undef. When clustering is enabled, this parameter is *required*. 
+
 ####database parameters####
 
 #####`$db`
@@ -189,9 +197,9 @@ Database type, defaults to 'postgres72'. Can be 'postgres72', 'mysql', 'oracle10
 
 #####`$dbschema`
 
-Set the schema 
+Set the schema
 
-The Default value is 'public' 
+The Default value is 'public'
 
 #####`$poolsize`
 
@@ -401,7 +409,7 @@ Defaults to 'JKS'. Valid options are 'JKS', 'PKCS12', 'JCEKS'.
     }
 ```
 
-### Hiera examples 
+### Hiera examples
 
 This example is used in production for 2000 users in an traditional enterprise environment. Your mileage may vary. The dbpassword can be stored using eyaml hiera extension.
 
@@ -531,4 +539,3 @@ export download_url="'http://my.local.server/'"
 ##Contributors
 
 The list of contributors can be found [here](https://github.com/brycejohnson/puppet-jira/graphs/contributors)
-

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -81,4 +81,13 @@ class jira::config inherits jira {
     notify  => Class['jira::service'],
   }
 
+  if $jira::datacenter {
+    file { "${jira::homedir}/cluster.properties":
+      content => template("jira/cluster.properties.erb"),
+      mode    => '0600',
+      require => [ Class['jira::install'],File[$jira::homedir] ],
+      notify  => Class['jira::service'],
+    }
+  }
+
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -83,7 +83,7 @@ class jira::config inherits jira {
 
   if $jira::datacenter {
     file { "${jira::homedir}/cluster.properties":
-      content => template("jira/cluster.properties.erb"),
+      content => template('jira/cluster.properties.erb'),
       mode    => '0600',
       require => [ Class['jira::install'],File[$jira::homedir] ],
       notify  => Class['jira::service'],

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -18,7 +18,7 @@
 # This module is used to install Jira.
 #
 # See README.md for more details
-# 
+#
 # === Authors
 #
 # Bryce Johnson
@@ -45,6 +45,9 @@ class jira (
   $shell        = '/bin/true',
 
   $enable_secure_admin_sessions = true,
+
+  $datacenter   = false,
+  $shared_homedir = '/var/jira',
 
   # Database Settings
   $db                      = 'postgresql',
@@ -128,7 +131,7 @@ class jira (
   # Tomcat Tunables
   $tomcatMaxThreads  = '150',
   $tomcatAcceptCount = '100',
-  
+
   # Reverse https proxy
   $proxy = {},
   # Options for the AJP connector

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -47,7 +47,7 @@ class jira (
   $enable_secure_admin_sessions = true,
 
   $datacenter   = false,
-  $shared_homedir = '/var/jira',
+  $shared_homedir = undef,
 
   # Database Settings
   $db                      = 'postgresql',
@@ -153,6 +153,10 @@ class jira (
   validate_bool($tomcatNativeSsl)
   validate_absolute_path($tomcatKeystoreFile)
   validate_re($tomcatKeystoreType, '^(JKS|JCEKS|PKCS12)$')
+
+  if $datacenter and !$shared_homedir {
+    fail("\$shared_homedir must be set when \$datacenter is true")
+  }
 
   # The default Jira product starting with version 7 is 'jira-software'
   if ((versioncmp($version, '7.0.0') > 0) and ($product == 'jira')) {

--- a/spec/classes/jira_config_spec.rb
+++ b/spec/classes/jira_config_spec.rb
@@ -20,6 +20,7 @@ describe 'jira::config' do
           it { should contain_file('/home/jira/dbconfig.xml')
             .with_content(/<url>jdbc:postgresql:\/\/localhost:5432\/jira<\/url>/)
             .with_content(/<schema-name>public<\/schema-name>/) }
+          it { should_not contain_file('/home/jira/cluster.properties') }
         end
 
         context 'mysql params' do
@@ -100,7 +101,7 @@ describe 'jira::config' do
           it { should contain_file('/opt/jira/atlassian-jira-6.3.4a-standalone/conf/server.xml')
             .with_content(/<Connector port=\"9229\"\s+address=\"127\.0\.0\.1\"\s+maxThreads=/m) }
         end
-        
+
         context 'tomcat context path' do
           let(:params) {{
             :version => '6.3.4a',
@@ -350,6 +351,18 @@ describe 'jira::config' do
             .with_content(/jira.websudo.is.disabled = true/) }
         end
 
+        context 'enable clustering' do
+          let(:params) {{
+            :version => '6.3.4a',
+            :javahome => '/opt/java',
+            :datacenter => true,
+            :shared_homedir => '/mnt/jira_shared_home_dir'
+          }}
+          it { should contain_file('/home/jira/cluster.properties')
+            .with_content(/jira.node.id = \S+/)
+            .with_content(/jira.shared.home = \/mnt\/jira_shared_home_dir/)
+          }
+        end
       end
     end
   end

--- a/templates/cluster.properties.erb
+++ b/templates/cluster.properties.erb
@@ -1,0 +1,4 @@
+# This ID must be unique across the cluster
+jira.node.id = <%= scope.lookupvar("fqdn") %>
+# The location of the shared home directory for all JIRA nodes
+jira.shared.home = <%= scope.lookupvar("jira::shared_homedir") %>


### PR DESCRIPTION
Setting up a node for a JIRA datacenter requires this additional file to be created and specification of a shared location. 