### PR TITLE
Change Default Download URL and use HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,7 +299,7 @@ defaults to ''
 #####`$downloadURL`
 
 The URL used to download the JIRA installation file.
-Defaults to 'http://www.atlassian.com/software/jira/downloads/binary/'
+Defaults to 'https://downloads.atlassian.com/software/jira/downloads/'
 
 #####`$staging_or_deploy`
 

--- a/jira.yaml
+++ b/jira.yaml
@@ -93,7 +93,7 @@ jira::jvm_optional: -XX:-HeapDumpOnOutOfMemoryError
 # the New and SR figures are purely optional
 # for heap dumps add -XX:-HeapDumpOnOutOfMemoryError
 # by default jira has 256m permgen which is a good setting to go with
-jira::downloadURL: "http://www.atlassian.com/software/jira/downloads/binary/"
+jira::downloadURL: 'https://downloads.atlassian.com/software/jira/downloads/'
 
 # Should puppet manage this service
 #  Boolean dictating if puppet should manage the service

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -88,7 +88,7 @@ class jira (
   $java_opts    = '',
 
   # Misc Settings
-  $downloadURL           = 'http://www.atlassian.com/software/jira/downloads/binary/',
+  $downloadURL           = 'https://downloads.atlassian.com/software/jira/downloads/',
   $disable_notifications = false,
 
   # Choose whether to use nanliu-staging, or mkrakowitzer-deploy

--- a/spec/classes/jira_install_deploy_spec.rb
+++ b/spec/classes/jira_install_deploy_spec.rb
@@ -18,13 +18,15 @@ describe 'jira::install' do
             :format      => 'tar.gz',
             :product     => 'jira',
             :version     => '6.4.3a',
-            :downloadURL => 'http://www.atlassian.com/software/jira/downloads/binary/',
+            :downloadURL => 'https://downloads.atlassian.com/software/jira/downloads/',
             :staging_or_deploy => 'deploy',
           }}
           it { should contain_group('jira') }
           it { should contain_user('jira').with_shell('/bin/true') }
           it 'should deploy jira 6.4.3a from tar.gz' do
-            should contain_deploy__file("atlassian-jira-6.4.3a.tar.gz")
+            should contain_deploy__file("atlassian-jira-6.4.3a.tar.gz").with(
+              'url' => 'https://downloads.atlassian.com/software/jira/downloads/',
+              )
           end
           it 'should manage the jira home directory' do
             should contain_file('/home/jira').with({

--- a/spec/classes/jira_install_staging_spec.rb
+++ b/spec/classes/jira_install_staging_spec.rb
@@ -19,13 +19,13 @@ describe 'jira::install' do
             :format      => 'tar.gz',
             :product     => 'jira',
             :version     => '6.4.3a',
-            :downloadURL => 'http://www.atlassian.com/software/jira/downloads/binary',
+            :downloadURL => 'https://downloads.atlassian.com/software/jira/downloads',
           }}
           it { should contain_group('jira') }
           it { should contain_user('jira').with_shell('/bin/true') }
           it 'should deploy jira 6.4.3a from tar.gz' do
             should contain_staging__file("atlassian-jira-6.4.3a.tar.gz").with({
-              'source' => 'http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.4.3a.tar.gz',
+              'source' => 'https://downloads.atlassian.com/software/jira/downloads/atlassian-jira-6.4.3a.tar.gz',
               })
             should contain_staging__extract("atlassian-jira-6.4.3a.tar.gz").with({
               'target' => '/opt/jira/atlassian-jira-6.4.3a-standalone',


### PR DESCRIPTION
The download URL appears to have moved as a lookup on the current URL
returns two HTTP 301 responses and one HTTP 302.

This patch replaced the current download URL with the redirected one and switches the protocol to use HTTPS.
```
$ curl -sIL http://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.4.12.tar.gz | egrep '(HTTP|Location)'
HTTP/1.1 301 Moved Permanently
Location: https://www.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.4.12.tar.gz
HTTP/1.1 301 Moved Permanently
Location: https://my.atlassian.com/software/jira/downloads/binary/atlassian-jira-6.4.12.tar.gz
HTTP/1.1 302 Found
Location: https://downloads.atlassian.com/software/jira/downloads/atlassian-jira-6.4.12.tar.gz
HTTP/1.1 200 OK
```